### PR TITLE
Test projects as rake task arguments and remove coveralls repository token from console output

### DIFF
--- a/coverage.rb
+++ b/coverage.rb
@@ -2,11 +2,13 @@ require_relative 'utils'
 
 task :cover, [:filter] do |task, args|
   coveralls = Dir.glob("packages/coveralls.net.*/tools/csmacnz.coveralls.exe").first
-  testProjects = Dir.glob("tests/*.Tests/*.Tests.csproj")
+  targetProjects = args.extras
+  testProjects = Dir.glob("tests/**/*.csproj").select{|path| targetProjects.include?(File.basename path)}
+
   openCover = Dir.glob("packages/OpenCover.*/tools/OpenCover.Console.exe").first
 
   targetArgs = testProjects.join(" ")
 
   Utils.run_cmd(openCover, ["-register:user", "-target:nunit3-console.exe", "-targetargs:#{targetArgs}", "-output:OpenCover.xml", "-filter:#{args.filter}", "-excludebyfile:*.Designer.cs"])
-  Utils.run_cmd(coveralls, ["--opencover", "-i", "OpenCover.xml", "--useRelativePaths", "--repoToken", ENV['COVERALLS_REPO_TOKEN'], "--commitId", ENV['APPVEYOR_REPO_COMMIT'], "--commitBranch", ENV['APPVEYOR_REPO_BRANCH'], "--commitAuthor", ENV['APPVEYOR_REPO_COMMIT_AUTHOR'], "--commitEmail", ENV['APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL'], "--commitMessage", ENV['APPVEYOR_REPO_COMMIT_MESSAGE'], "--jobId", ENV['APPVEYOR_BUILD_NUMBER'], "--serviceName", "appveyor"])
+  Utils.run_cmd(coveralls, ["--opencover", "-i", "OpenCover.xml", "--useRelativePaths", "--repoTokenVariable", "COVERALLS_REPO_TOKEN", "--commitId", ENV['APPVEYOR_REPO_COMMIT'], "--commitBranch", ENV['APPVEYOR_REPO_BRANCH'], "--commitAuthor", ENV['APPVEYOR_REPO_COMMIT_AUTHOR'], "--commitEmail", ENV['APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL'], "--commitMessage", ENV['APPVEYOR_REPO_COMMIT_MESSAGE'], "--jobId", ENV['APPVEYOR_BUILD_NUMBER'], "--serviceName", "appveyor"])
 end


### PR DESCRIPTION
Fixes #3 Do not expose coveralls repository token in console
Fixes #4 Add test projects list to rake task parameters 