### PR TITLE
Fixes #6 - Change code coverage service to codecov.io

### DIFF
--- a/coverage.rb
+++ b/coverage.rb
@@ -1,14 +1,12 @@
 require_relative 'utils'
 
-task :cover, [:filter] do |task, args|
-  coveralls = Dir.glob("packages/coveralls.net.*/tools/csmacnz.coveralls.exe").first
-  targetProjects = args.extras
-  testProjects = Dir.glob("tests/**/*.csproj").select{|path| targetProjects.include?(File.basename path)}
+module Coverage
+  def self.cover(filter, targetProjects)
+    testProjects = Dir.glob("tests/**/*.csproj").select{|path| targetProjects.include?(File.basename path)}
+    openCover = Dir.glob("packages/OpenCover.*/tools/OpenCover.Console.exe").first
+    targetArgs = testProjects.join(" ")
 
-  openCover = Dir.glob("packages/OpenCover.*/tools/OpenCover.Console.exe").first
-
-  targetArgs = testProjects.join(" ")
-
-  Utils.run_cmd(openCover, ["-register:user", "-target:nunit3-console.exe", "-targetargs:#{targetArgs}", "-output:OpenCover.xml", "-filter:#{args.filter}", "-excludebyfile:*.Designer.cs"])
-  Utils.run_cmd(coveralls, ["--opencover", "-i", "OpenCover.xml", "--useRelativePaths", "--repoTokenVariable", "COVERALLS_REPO_TOKEN", "--commitId", ENV['APPVEYOR_REPO_COMMIT'], "--commitBranch", ENV['APPVEYOR_REPO_BRANCH'], "--commitAuthor", ENV['APPVEYOR_REPO_COMMIT_AUTHOR'], "--commitEmail", ENV['APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL'], "--commitMessage", ENV['APPVEYOR_REPO_COMMIT_MESSAGE'], "--jobId", ENV['APPVEYOR_BUILD_NUMBER'], "--serviceName", "appveyor"])
+    Utils.run_cmd(openCover, ["-register:user", "-target:nunit3-console.exe", "-targetargs:#{targetArgs}", "-output:OpenCover.xml", "-filter:#{filter}", "-excludebyfile:*.Designer.cs"])
+    Utils.run_cmd("codecov", ["-f", "OpenCover.xml"])
+  end
 end


### PR DESCRIPTION
As discussed, this is now a method instead of task.
Also, removed support for coveralls.io and added support for codecov.io